### PR TITLE
VSP-23066: Use launch template instead of launch config, always encrypt volumes

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -95,6 +95,10 @@ resource "aws_launch_template" "launch_template" {
   ebs_optimized          = var.root_volume_ebs_optimized
   update_default_version = var.update_default_version
 
+  monitoring {
+    enabled = true
+  }
+
   iam_instance_profile {
     name = var.enable_iam_setup ? element(
       concat(aws_iam_instance_profile.instance_profile.*.name, [""]),

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -16,7 +16,10 @@ terraform {
 resource "aws_autoscaling_group" "autoscaling_group" {
   name_prefix = var.cluster_name
 
-  launch_configuration = aws_launch_configuration.launch_configuration.name
+  launch_template {
+    id      = aws_launch_template.launch_template.id
+    version = var.launch_template_version
+  }
 
   availability_zones  = var.availability_zones
   vpc_zone_identifier = var.subnet_ids
@@ -83,33 +86,48 @@ resource "aws_autoscaling_group" "autoscaling_group" {
 # CREATE LAUNCH CONFIGURATION TO DEFINE WHAT RUNS ON EACH INSTANCE IN THE ASG
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "aws_launch_configuration" "launch_configuration" {
-  name_prefix   = "${var.cluster_name}-"
-  image_id      = var.ami_id
-  instance_type = var.instance_type
-  user_data     = var.user_data
-  spot_price    = var.spot_price
+resource "aws_launch_template" "launch_template" {
+  name_prefix            = "${var.cluster_name}-"
+  image_id               = var.ami_id
+  instance_type          = var.instance_type
+  user_data              = var.user_data
+  key_name               = var.ssh_key_name
+  ebs_optimized          = var.root_volume_ebs_optimized
+  update_default_version = var.update_default_version
 
-  iam_instance_profile = var.enable_iam_setup ? element(
-    concat(aws_iam_instance_profile.instance_profile.*.name, [""]),
-    0,
-  ) : var.iam_instance_profile_name
-  key_name = var.ssh_key_name
+  iam_instance_profile {
+    name = var.enable_iam_setup ? element(
+      concat(aws_iam_instance_profile.instance_profile.*.name, [""]),
+      0,
+    ) : var.iam_instance_profile_name
+  }
 
-  security_groups = concat(
-    [aws_security_group.lc_security_group.id],
-    var.additional_security_group_ids,
-  )
-  placement_tenancy           = var.tenancy
-  associate_public_ip_address = var.associate_public_ip_address
+  placement {
+    tenancy = var.tenancy
+  }
 
-  ebs_optimized = var.root_volume_ebs_optimized
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups             = concat(
+      [aws_security_group.lc_security_group.id],
+      var.additional_security_group_ids,
+    )
+  }
 
-  root_block_device {
-    volume_type           = var.root_volume_type
-    volume_size           = var.root_volume_size
-    delete_on_termination = var.root_volume_delete_on_termination
-    encrypted             = var.root_volume_encrypted
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = var.root_volume_delete_on_termination
+      encrypted             = true
+      volume_type           = var.root_volume_type
+      volume_size           = var.root_volume_size
+    }
+  }
+
+  instance_market_options {
+    spot_options {
+      max_price = var.spot_price
+    }
   }
 
   # Important note: whenever using a launch configuration with an auto scaling group, you must set

--- a/modules/consul-cluster/outputs.tf
+++ b/modules/consul-cluster/outputs.tf
@@ -8,9 +8,9 @@ output "cluster_size" {
   description = "This is the desired size of the consul cluster in the autoscaling group"
 }
 
-output "launch_config_name" {
-  value       = aws_launch_configuration.launch_configuration.name
-  description = "This is the name of the launch_configuration used to bootstrap the cluster instances"
+output "launch_template_name" {
+  value       = aws_launch_template.launch_template.name
+  description = "This is the name of the launch_template used to bootstrap the cluster instances"
 }
 
 output "iam_role_arn" {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -315,3 +315,15 @@ variable "protect_from_scale_in" {
   type        = bool
   default     = false
 }
+
+variable "launch_template_version" {
+  description = "Launch template version.  Can be version number, $Latest, or $Default."
+  type        = string
+  default     = "$Latest"
+}
+
+variable "update_default_version" {
+  description = "Whether to update Default Version each update. Conflicts with default_version."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Encrypt Consul servers' root EBS volumes as part of [VSP-23066](https://dreambox.atlassian.net/browse/VSP-23066).  This also updates the module to use launch templates instead of launch configs, which will be deprecated soon (see [VSP-23047](https://dreambox.atlassian.net/browse/VSP-23047)).

The original repo is deprecated: 
>This repository is no longer supported, please consider using [this repository](https://registry.terraform.io/modules/hashicorp/consul-starter/aws/latest) for the latest and most supported version for Consul.